### PR TITLE
Fix Mercury, Coal and Charcoal

### DIFF
--- a/src/main/java/com/mcmoddev/basemetals/init/Blocks.java
+++ b/src/main/java/com/mcmoddev/basemetals/init/Blocks.java
@@ -69,8 +69,10 @@ public class Blocks extends com.mcmoddev.lib.init.Blocks {
 		}
 
 		if (Options.enableCoal) {
-//			Materials.vanilla_coal.block = net.minecraft.init.Blocks.COAL_BLOCK;
-//			Materials.vanilla_coal.ore = net.minecraft.init.Blocks.COAL_ORE;
+			final MetalMaterial material = Materials.vanilla_coal;
+			
+			material.block = net.minecraft.init.Blocks.COAL_BLOCK;
+			material.ore = net.minecraft.init.Blocks.COAL_ORE;
 		}
 
 		if (Options.enableColdIron) {

--- a/src/main/java/com/mcmoddev/basemetals/init/Fluids.java
+++ b/src/main/java/com/mcmoddev/basemetals/init/Fluids.java
@@ -4,6 +4,7 @@ import com.mcmoddev.basemetals.util.Config.Options;
 
 import net.minecraftforge.fluids.BlockFluidBase;
 import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
 
 /**
  * This class initializes all fluids in Base Metals.
@@ -30,6 +31,11 @@ public class Fluids extends com.mcmoddev.lib.init.Fluids {
 			return;
 		}
 
+		if( Options.enableCoal ) {
+			addFluid(Materials.vanilla_coal, 2000, 10000, 769, 10);
+			addFluidBlock(Materials.vanilla_coal);
+		}
+		
 		if (Options.enableAdamantine) {
 			addFluid(Materials.adamantine, 2000, 10000, 769, 10);
 			addFluidBlock(Materials.adamantine);

--- a/src/main/java/com/mcmoddev/basemetals/init/Fluids.java
+++ b/src/main/java/com/mcmoddev/basemetals/init/Fluids.java
@@ -14,9 +14,6 @@ import net.minecraftforge.fluids.FluidRegistry;
  */
 public class Fluids extends com.mcmoddev.lib.init.Fluids {
 
-	public static Fluid fluidMercury = null;
-	public static BlockFluidBase fluidBlockMercury = null;
-
 	private static boolean initDone = false;
 
 	private Fluids() {
@@ -97,8 +94,8 @@ public class Fluids extends com.mcmoddev.lib.init.Fluids {
 		}
 
 		if (Options.enableMercury) {
-			fluidMercury = addFluid("mercury", 13594, 2000, 769, 0);
-			fluidBlockMercury = addFluidBlock("mercury");
+			addFluid("mercury", 13594, 2000, 769, 0);
+			addFluidBlock("mercury");
 		}
 
 		if (Options.enableMithril) {

--- a/src/main/java/com/mcmoddev/basemetals/init/Items.java
+++ b/src/main/java/com/mcmoddev/basemetals/init/Items.java
@@ -85,15 +85,14 @@ public class Items extends com.mcmoddev.lib.init.Items {
 		}
 
 		if (Options.enableCoal) {
-			coal_nugget = addItem(new Item(), "coal_nugget", null, ItemGroups.tab_items);
-			OreDictionary.registerOre(Oredicts.NUGGETCOAL, coal_nugget);
-
-			coal_powder = addItem(new Item(), "coal_powder", null, ItemGroups.tab_items);
-			OreDictionary.registerOre(Oredicts.DUSTCOAL, coal_powder);
-
-			coal_smallpowder = addItem(new Item(), "coal_smallpowder", null, ItemGroups.tab_items);
-			OreDictionary.registerOre(Oredicts.DUSTTINYCOAL, coal_smallpowder);
-			OreDictionary.registerOre(Oredicts.DUSTSMALLCOAL, coal_smallpowder);
+			final MetalMaterial material = Materials.vanilla_coal;
+			material.ingot = net.minecraft.init.Items.COAL;
+			
+			coal_nugget = createNugget(material);
+			coal_powder = createPowder(material);
+			coal_smallpowder = createSmallPowder(material);
+			// quick&dirty fix for Coal not working directly in the smeltery
+			OreDictionary.registerOre("ingotCoal", Materials.vanilla_coal.ingot);
 		}
 
 		if (Options.enableColdIron) {

--- a/src/main/java/com/mcmoddev/basemetals/init/Items.java
+++ b/src/main/java/com/mcmoddev/basemetals/init/Items.java
@@ -221,25 +221,12 @@ public class Items extends com.mcmoddev.lib.init.Items {
 		}
 
 		if (Options.enableMercury) {
-			// mercury is special
-			mercury_ingot = addItem(new Item(), "mercury_ingot", null, ItemGroups.tab_items);
-//			itemRegistry.put("mercury_ingot", mercury_ingot);
-			OreDictionary.registerOre(Oredicts.INGOTMERCURY, mercury_ingot);
-			OreDictionary.registerOre(Oredicts.QUICKSILVER, mercury_ingot);
+			final MetalMaterial material = Materials.mercury;
+			material.ingot = createIngot( material );
 
-			mercury_nugget = addItem(new Item(), "mercury_nugget", null, ItemGroups.tab_items);
-//			itemRegistry.put("mercury_ingot", mercury_nugget);
-			OreDictionary.registerOre(Oredicts.NUGGETMERCURY, mercury_nugget);
-//			OreDictionary.registerOre(Oredicts.QUICKSILVER, mercury_nugget);
-
-			mercury_powder = addItem(new Item(), "mercury_powder", null, ItemGroups.tab_items);
-//			itemRegistry.put("mercury_powder", mercury_powder);
-			OreDictionary.registerOre(Oredicts.DUSTMERCURY, mercury_powder);
-
-			mercury_smallpowder = addItem(new Item(), "mercury_smallpowder", null, ItemGroups.tab_items);
-//			itemRegistry.put("mercury_smallpowder", mercury_smallpowder);
-			OreDictionary.registerOre(Oredicts.DUSTTINYMERCURY, mercury_smallpowder);
-			OreDictionary.registerOre(Oredicts.DUSTSMALLMERCURY, mercury_smallpowder);
+			mercury_nugget = createNugget(material);
+			mercury_powder = createPowder(material);
+			mercury_smallpowder = createSmallPowder(material);
 		}
 
 		if (Options.enableMithril) {

--- a/src/main/java/com/mcmoddev/basemetals/init/Items.java
+++ b/src/main/java/com/mcmoddev/basemetals/init/Items.java
@@ -5,6 +5,7 @@ import com.mcmoddev.lib.material.MetalMaterial;
 import com.mcmoddev.lib.util.Oredicts;
 
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 
 /**
@@ -73,15 +74,12 @@ public class Items extends com.mcmoddev.lib.init.Items {
 		}
 
 		if (Options.enableCharcoal) {
-			charcoal_nugget = addItem(new Item(), "charcoal_nugget", null, ItemGroups.tab_items);
-			OreDictionary.registerOre(Oredicts.NUGGETCHARCOAL, charcoal_nugget);
-
-			charcoal_powder = addItem(new Item(), "charcoal_powder", null, ItemGroups.tab_items);
-			OreDictionary.registerOre(Oredicts.DUSTCHARCOAL, charcoal_powder);
-
-			charcoal_smallpowder = addItem(new Item(), "charcoal_smallpowder", null, ItemGroups.tab_items);
-			OreDictionary.registerOre(Oredicts.DUSTTINYCHARCOAL, charcoal_smallpowder);
-			OreDictionary.registerOre(Oredicts.DUSTSMALLCHARCOAL, charcoal_smallpowder);
+			final MetalMaterial material = Materials.vanilla_charcoal;
+			material.ingot = new ItemStack( net.minecraft.init.Items.COAL, 1, 1 ).getItem();
+			
+			charcoal_nugget = createNugget(material);
+			charcoal_powder = createPowder(material);
+			charcoal_smallpowder = createSmallPowder(material);
 		}
 
 		if (Options.enableCoal) {

--- a/src/main/java/com/mcmoddev/basemetals/init/Materials.java
+++ b/src/main/java/com/mcmoddev/basemetals/init/Materials.java
@@ -25,6 +25,7 @@ public abstract class Materials extends com.mcmoddev.lib.init.Materials {
 	public static MetalMaterial electrum;
 	public static MetalMaterial invar;
 	public static MetalMaterial lead;
+	public static MetalMaterial mercury;
 	public static MetalMaterial mithril;
 	public static MetalMaterial nickel;
 	public static MetalMaterial pewter;
@@ -142,6 +143,12 @@ public abstract class Materials extends com.mcmoddev.lib.init.Materials {
 			lead = createMaterial("lead", 1, 1, 1, 0xFF7B7B7B).setBaseDamage(4f);
 			lead.materialType = MetalMaterial.MaterialType.METAL;
 		}
+		
+		if (Options.enableMercury) {
+			mercury = createMaterial("mercury", 1, 1, 1, 0);
+			mercury.materialType = MetalMaterial.MaterialType.METAL;
+		}
+		
 		if (Options.enableMithril) {
 			mithril = createAlloyMaterial("mithril", 9, 9, 9, 0xFFF4FFFF);
 			mithril.materialType = MetalMaterial.MaterialType.METAL;

--- a/src/main/java/com/mcmoddev/basemetals/init/Materials.java
+++ b/src/main/java/com/mcmoddev/basemetals/init/Materials.java
@@ -41,7 +41,8 @@ public abstract class Materials extends com.mcmoddev.lib.init.Materials {
 	public static MetalMaterial vanilla_iron;
 	public static MetalMaterial vanilla_gold;
 	public static MetalMaterial vanilla_diamond;
-
+	public static MetalMaterial vanilla_coal;
+	
 	private static boolean initDone = false;
 
 	protected Materials() {
@@ -79,6 +80,11 @@ public abstract class Materials extends com.mcmoddev.lib.init.Materials {
 		vanilla_diamond.isVanilla = true;
 		vanilla_diamond.materialType = MetalMaterial.MaterialType.GEM;
 
+		if( Options.enableCoal ) {
+			vanilla_coal = createMaterial("coal", 5, 4, 2, 0xFF000000);
+			vanilla_coal.isVanilla = true;
+			vanilla_coal.materialType = MetalMaterial.MaterialType.MINERAL;
+		}		
 		// Mod Materials
 		if (Options.enableAdamantine) {
 			adamantine = createMaterial("adamantine", 12, 100, 0, 0xFF53393F).setBlastResistance(2000f);

--- a/src/main/java/com/mcmoddev/basemetals/init/Materials.java
+++ b/src/main/java/com/mcmoddev/basemetals/init/Materials.java
@@ -42,6 +42,7 @@ public abstract class Materials extends com.mcmoddev.lib.init.Materials {
 	public static MetalMaterial vanilla_gold;
 	public static MetalMaterial vanilla_diamond;
 	public static MetalMaterial vanilla_coal;
+	public static MetalMaterial vanilla_charcoal;
 	
 	private static boolean initDone = false;
 
@@ -81,10 +82,17 @@ public abstract class Materials extends com.mcmoddev.lib.init.Materials {
 		vanilla_diamond.materialType = MetalMaterial.MaterialType.GEM;
 
 		if( Options.enableCoal ) {
-			vanilla_coal = createMaterial("coal", 5, 4, 2, 0xFF000000);
+			vanilla_coal = createMaterial("coal", 4, 4, 2, 0xFF000000);
 			vanilla_coal.isVanilla = true;
 			vanilla_coal.materialType = MetalMaterial.MaterialType.MINERAL;
 		}		
+
+		if( Options.enableCharcoal ) {
+			vanilla_charcoal = createOrelessMaterial("charcoal", 4, 4, 2, 0xFF000000);
+			vanilla_charcoal.isVanilla = true;
+			vanilla_charcoal.materialType = MetalMaterial.MaterialType.MINERAL;
+		}		
+		
 		// Mod Materials
 		if (Options.enableAdamantine) {
 			adamantine = createMaterial("adamantine", 12, 100, 0, 0xFF53393F).setBlastResistance(2000f);

--- a/src/main/java/com/mcmoddev/basemetals/init/Recipes.java
+++ b/src/main/java/com/mcmoddev/basemetals/init/Recipes.java
@@ -295,7 +295,7 @@ public class Recipes extends com.mcmoddev.lib.init.Recipes {
 			if (FluidRegistry.isUniversalBucketEnabled()) {
 				final UniversalBucket universalBucket = ForgeModContainer.getInstance().universalBucket;
 				final ItemStack bucketMercury = new ItemStack(universalBucket, 1, 0);
-				universalBucket.fill(bucketMercury, new FluidStack(Fluids.fluidMercury, universalBucket.getCapacity()), true);
+				universalBucket.fill(bucketMercury, new FluidStack(Materials.mercury.fluid, universalBucket.getCapacity()), true);
 				GameRegistry.addRecipe(new ShapelessOreRecipe(bucketMercury, net.minecraft.init.Items.BUCKET, Oredicts.INGOTMERCURY, Oredicts.INGOTMERCURY, Oredicts.INGOTMERCURY, Oredicts.INGOTMERCURY, Oredicts.INGOTMERCURY, Oredicts.INGOTMERCURY, Oredicts.INGOTMERCURY, Oredicts.INGOTMERCURY));
 			}
 		}
@@ -315,12 +315,6 @@ public class Recipes extends com.mcmoddev.lib.init.Recipes {
 //			GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(net.minecraft.init.Items.SHEARS), "x ", " x", 'x', Oredicts.INGOTSTEEL));
 //			GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(net.minecraft.init.Items.SHEARS), " x", "x ", 'x', Oredicts.INGOTSTEEL));
 //			GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(net.minecraft.init.Items.SHIELD), "wxw", "www", " w ", 'w', Oredicts.PLANKWOOD, 'x', Oredicts.INGOTSTEEL));
-		}
-
-		if (Options.enableMercury) {
-			CrusherRecipeRegistry.addNewCrusherRecipe(Oredicts.OREMERCURY, new ItemStack(Items.mercury_powder, 2));
-			GameRegistry.addSmelting(Items.mercury_powder, new ItemStack(Items.mercury_ingot, 1), 0);
-			GameRegistry.addSmelting(Blocks.mercury_ore, new ItemStack(Items.mercury_ingot, 1), 1);
 		}
 
 		// new recipes using rods and gears

--- a/src/main/java/com/mcmoddev/basemetals/proxy/CommonProxy.java
+++ b/src/main/java/com/mcmoddev/basemetals/proxy/CommonProxy.java
@@ -47,7 +47,7 @@ public class CommonProxy {
 				if (mapping.type.equals(GameRegistry.Type.BLOCK)) {
 					if ((mapping.resourceLocation.getResourcePath().equals("liquid_mercury")) && (mapping.type.equals(GameRegistry.Type.BLOCK))) {
 						 if (Options.enableMercury) {
-							 mapping.remap(Fluids.fluidBlockMercury);
+							 mapping.remap(Materials.mercury.fluidBlock);
 						 }
 					}
 				} else if (mapping.type.equals(GameRegistry.Type.ITEM)) {


### PR DESCRIPTION
Coal and Charcoal have long been commented out of the BMe code - change that back so that Coal, at least, can get used in the Smeltery to help produce Steel.

Mercury has been a hold-over from pre-MetalMaterial versions of the code, special-cased and only barely working. It has now, like Coal and Charcoal, been promoted to full MetalMaterial.

This makes a lot of stuff work, opens some possibilities and gets some items off Jas's TODO. It has also been tested and found to be functional. Further PR's may come to patch the materials various stats.