### PR TITLE
Rework general item creation code

### DIFF
--- a/src/main/java/com/mcmoddev/basemetals/init/Recipes.java
+++ b/src/main/java/com/mcmoddev/basemetals/init/Recipes.java
@@ -64,7 +64,6 @@ public class Recipes extends com.mcmoddev.lib.init.Recipes {
 		if (Options.enableIron) {
 			material = Materials.vanilla_iron;
 			oreDictName = material.getCapitalizedName();
-			runVanillaMaterialRecipe(material);
 
 			GameRegistry.addRecipe(new ShapelessOreRecipe(new ItemStack(material.nugget, 9), new ItemStack(material.ingot))); // Not needed for 1.11.1+
 			GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.ingot), "xxx", "xxx", "xxx", 'x', material.nugget)); // Not needed for 1.11.1+
@@ -74,14 +73,12 @@ public class Recipes extends com.mcmoddev.lib.init.Recipes {
 		if (Options.enableDiamond) {
 			material = Materials.vanilla_diamond;
 			oreDictName = material.getCapitalizedName();
-			runVanillaMaterialRecipe(material);
 		}
 
 		// Gold items
 		if (Options.enableGold) {
 			material = Materials.vanilla_gold;
 			oreDictName = material.getCapitalizedName();
-			runVanillaMaterialRecipe(material);
 		}
 
 		if (Options.enableCharcoal) {
@@ -235,52 +232,5 @@ public class Recipes extends com.mcmoddev.lib.init.Recipes {
 		// TODO
 		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(net.minecraft.init.Blocks.LEVER, 1), "x", "y", 'x', Oredicts.ROD, 'y', Oredicts.COBBLESTONE));
 		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(Blocks.human_detector, 1), "xx", "yy", 'x', Oredicts.INGOTBRICK, 'y', Oredicts.GEAR));
-	}
-	
-	private static void runVanillaMaterialRecipe(MetalMaterial material) {
-		final String oreDictName = material.getCapitalizedName();
-
-		if (!Options.disableAllHammerRecipes) {
-			GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.crackhammer), "x", "/", "/", 'x', Oredicts.BLOCK + oreDictName, '/', Oredicts.STICKWOOD));
-		}
-		if (material.powder != null) {
-			CrusherRecipeRegistry.addNewCrusherRecipe(Oredicts.ORE + oreDictName, new ItemStack(material.powder, 2));
-			if (material.block != null) {
-				CrusherRecipeRegistry.addNewCrusherRecipe(Oredicts.BLOCK + oreDictName, new ItemStack(material.powder, 9));
-			}
-			if (material.ingot != null) {
-				CrusherRecipeRegistry.addNewCrusherRecipe(Oredicts.INGOT + oreDictName, new ItemStack(material.powder, 1));
-				GameRegistry.addSmelting(material.powder, new ItemStack(material.ingot), 0f);
-			}
-			if (material.smallpowder != null) {
-				GameRegistry.addRecipe(new ShapelessOreRecipe(new ItemStack(material.smallpowder, 9), new ItemStack(material.powder)));
-				GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.powder), "xxx", "xxx", "xxx", 'x', new ItemStack(material.smallpowder)));
-				if (material.nugget != null) {
-					CrusherRecipeRegistry.addNewCrusherRecipe(Oredicts.NUGGET + oreDictName, new ItemStack(material.smallpowder, 1));
-				}
-			}
-		}
-		if (material.rod != null) {
-			GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.rod, 4), "x", "x", 'x', Oredicts.INGOT + oreDictName));
-			OreDictionary.registerOre(Oredicts.STICK + oreDictName, material.rod);
-			OreDictionary.registerOre(Oredicts.ROD + oreDictName, material.rod);
-			OreDictionary.registerOre(Oredicts.ROD, material.rod);
-			if (material.nugget != null) {
-				GameRegistry.addSmelting(material.rod, new ItemStack(material.nugget, 4), 0);
-			}
-			if (material.bars != null) {
-				GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.bars, 4), "xxx", 'x', Oredicts.ROD + oreDictName));
-			}
-		}
-		if (material.gear != null) {
-			if (material.rod != null) {
-				GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.gear, Config.Options.gearQuantity), " x ", "x/x", " x ", 'x', Oredicts.INGOT + oreDictName, '/', Oredicts.ROD + oreDictName));
-			}
-			OreDictionary.registerOre(Oredicts.GEAR + oreDictName, material.gear);
-			OreDictionary.registerOre(Oredicts.GEAR, material.gear);
-		}
-		if (material.plate != null) {
-			GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.plate, Config.Options.plateQuantity), "xxx", 'x', Oredicts.INGOT + oreDictName));
-		}
 	}
 }

--- a/src/main/java/com/mcmoddev/lib/init/Recipes.java
+++ b/src/main/java/com/mcmoddev/lib/init/Recipes.java
@@ -4,6 +4,7 @@ import com.mcmoddev.basemetals.registry.CrusherRecipeRegistry;
 import com.mcmoddev.basemetals.util.Config;
 import com.mcmoddev.basemetals.util.Config.Options;
 import com.mcmoddev.lib.material.MetalMaterial;
+import com.mcmoddev.lib.material.IMetalObject;
 import com.mcmoddev.lib.util.Oredicts;
 
 import net.minecraft.item.ItemStack;
@@ -136,10 +137,10 @@ public abstract class Recipes {
 	protected static void initGeneralRecipes() {
 
 		for (final MetalMaterial material : Materials.getAllMaterials()) {
-			if (material.isVanilla) {
+/*			if (material.isVanilla) {
 				continue;
 			}
-
+*/
 			final String oreDictName = material.getCapitalizedName();
 			// NOTE: smelting XP is based on output item, not input item
 			final float oreSmeltXP = material.getOreSmeltXP();
@@ -149,7 +150,7 @@ public abstract class Recipes {
 					CrusherRecipeRegistry.addNewCrusherRecipe(Oredicts.ORE + oreDictName, new ItemStack(material.powder, 2));
 				}
 
-				if (material.ingot != null) {
+				if ((material.ingot != null) && (material.ingot instanceof IMetalObject)) {
 					GameRegistry.addSmelting(material.ore, new ItemStack(material.ingot, 1), oreSmeltXP);
 				}
 			}
@@ -193,93 +194,7 @@ public abstract class Recipes {
 
 				// Vanilla has all these things where they matter, may want some handling for Emerald & Obsidian in future however, maybe move this block to a seperate function?
 				if (!(material.isVanilla)) {
-					if (material.boots != null) {
-						GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.boots), "x x", "x x", 'x', Oredicts.INGOT + oreDictName));
-						if (Config.Options.furnaceCheese) {
-							GameRegistry.addSmelting(material.boots, new ItemStack(material.ingot, 4), 0);
-						} else if (Config.Options.furnace1112) {						
-							GameRegistry.addSmelting(material.boots, new ItemStack(material.nugget, 1), 0);
-						}
-					}
-
-					if (material.helmet != null) {
-						GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.helmet), "xxx", "x x", 'x', Oredicts.INGOT + oreDictName));
-						if (Config.Options.furnaceCheese) {
-							GameRegistry.addSmelting(material.helmet, new ItemStack(material.ingot, 5), 0);
-						} else if (Config.Options.furnace1112) {						
-							GameRegistry.addSmelting(material.helmet, new ItemStack(material.nugget, 1), 0);
-						}
-					}
-
-					if (material.chestplate != null) {
-						GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.chestplate), "x x", "xxx", "xxx", 'x', Oredicts.INGOT + oreDictName));
-						if (Config.Options.furnaceCheese) {
-							GameRegistry.addSmelting(material.chestplate, new ItemStack(material.ingot, 8), 0);
-						} else if (Config.Options.furnace1112) {						
-							GameRegistry.addSmelting(material.chestplate, new ItemStack(material.nugget, 1), 0);
-						}
-					}
-
-					if (material.leggings != null) {
-						GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.leggings), "xxx", "x x", "x x", 'x', Oredicts.INGOT + oreDictName));
-						if (Config.Options.furnaceCheese) {
-							GameRegistry.addSmelting(material.chestplate, new ItemStack(material.leggings, 7), 0);
-						} else if (Config.Options.furnace1112) {						
-							GameRegistry.addSmelting(material.leggings, new ItemStack(material.nugget, 1), 0);
-						}
-					}
-
-					if (material.axe != null) {
-						GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.axe), "xx", "x/", " /", 'x', Oredicts.INGOT + oreDictName, '/', Oredicts.STICKWOOD));
-						// 	GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.axe), "xx", "/x", "/ ", 'x', Oredicts.INGOT + oreDictName, '/', Oredicts.STICKWOOD));
-						if (Config.Options.furnaceCheese) {
-							GameRegistry.addSmelting(material.axe, new ItemStack(material.ingot, 3), 0);
-						} else if (Config.Options.furnace1112) {						
-							GameRegistry.addSmelting(material.axe, new ItemStack(material.nugget, 1), 0);
-						}
-					}
-
-					if (material.hoe != null) {
-						GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.hoe), "xx", " /", " /", 'x', Oredicts.INGOT + oreDictName, '/', Oredicts.STICKWOOD));
-						// 	GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.hoe), "xx", "/ ", "/ ", 'x', INGOT + oreDictName, '/', STICKWOOD));
-						if (Config.Options.furnaceCheese) {
-							GameRegistry.addSmelting(material.hoe, new ItemStack(material.ingot, 2), 0);
-						} else if (Config.Options.furnace1112) {						
-							GameRegistry.addSmelting(material.hoe, new ItemStack(material.nugget, 1), 0);
-						}
-					}
-
-					if (material.pickaxe != null) {
-						GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.pickaxe), "xxx", " / ", " / ", 'x', Oredicts.INGOT + oreDictName, '/', Oredicts.STICKWOOD));
-						if (Config.Options.furnaceCheese) {
-							GameRegistry.addSmelting(material.pickaxe, new ItemStack(material.ingot, 3), 0);
-						} else if (Config.Options.furnace1112) {						
-							GameRegistry.addSmelting(material.pickaxe, new ItemStack(material.nugget, 1), 0);
-						}
-					}
-
-					if (material.shovel != null) {
-						GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.shovel), "x", "/", "/", 'x', Oredicts.INGOT + oreDictName, '/', Oredicts.STICKWOOD));
-						if (Config.Options.furnaceCheese) {
-							GameRegistry.addSmelting(material.shovel, new ItemStack(material.ingot, 1), 0);
-						} else if (Config.Options.furnace1112) {						
-							GameRegistry.addSmelting(material.shovel, new ItemStack(material.nugget, 1), 0);
-						}
-					}
-
-					if (material.sword != null) {
-						GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.sword), "x", "x", "/", 'x', Oredicts.INGOT + oreDictName, '/', Oredicts.STICKWOOD));
-						if (Config.Options.furnaceCheese) {
-							GameRegistry.addSmelting(material.sword, new ItemStack(material.ingot, 2), 0);
-						} else if (Config.Options.furnace1112) {						
-							GameRegistry.addSmelting(material.sword, new ItemStack(material.nugget, 1), 0);
-						}
-					}
-
-					if (material.shears != null) {
-						GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.shears), " x", "x ", 'x', Oredicts.INGOT + oreDictName));
-						GameRegistry.addSmelting(material.shears, new ItemStack(material.ingot, 2), 0);
-					}
+					generateBaseTools(material, oreDictName);
 				}
 
 				if (material.powder != null) {
@@ -291,13 +206,13 @@ public abstract class Recipes {
 					GameRegistry.addSmelting(material.blend, new ItemStack(material.ingot, 1), oreSmeltXP);
 				}
 
-				if (material.nugget != null) {
+				if ((material.nugget != null) && (material.nugget instanceof IMetalObject)) {
 //2017					GameRegistry.addRecipe(new ShapelessOreRecipe(new ItemStack(material.nugget, 9), new ItemStack(material.ingot)));
 					GameRegistry.addRecipe(new ShapelessOreRecipe(new ItemStack(material.nugget, 9), Oredicts.INGOT + oreDictName));
 					GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.ingot), "xxx", "xxx", "xxx", 'x', Oredicts.NUGGET + oreDictName));
 				}
 
-				if (material.block != null) {
+				if ( (material.block) != null && (material.block instanceof IMetalObject)) {
 //2017					GameRegistry.addRecipe(new ShapelessOreRecipe(new ItemStack(material.ingot, 9), new ItemStack(material.block)));
 					GameRegistry.addRecipe(new ShapelessOreRecipe(new ItemStack(material.ingot, 9), Oredicts.BLOCK + oreDictName));
 					GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.block), "xxx", "xxx", "xxx", 'x', Oredicts.INGOT + oreDictName));
@@ -308,12 +223,12 @@ public abstract class Recipes {
 					GameRegistry.addSmelting(material.plate, new ItemStack(material.ingot, 1), 0);
 				}
 
-				if (material.pressure_plate != null) {
+				if ((material.pressure_plate != null) && (material.pressure_plate instanceof IMetalObject)) {
 					GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.pressure_plate), "xx", 'x', Oredicts.INGOT + oreDictName));
 					GameRegistry.addSmelting(material.pressure_plate, new ItemStack(material.ingot, 2), 0);
 				}
 
-				if (material.bars != null) {
+				if ((material.bars != null) && (material.bars instanceof IMetalObject)) {
 					GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.bars, 16), "xxx", "xxx", 'x', Oredicts.INGOT + oreDictName));
 					GameRegistry.addSmelting(material.bars, new ItemStack(material.nugget, 3), 0); // roughly half a nugget loss
 //					OreDictionary.registerOre(Oredicts.BARS, material.bars);
@@ -325,7 +240,7 @@ public abstract class Recipes {
 //					OreDictionary.registerOre(Oredicts.ROD, material.rod);
 				}
 
-				if (material.door != null) {
+				if ((material.door != null) && (material.door instanceof IMetalObject)) {
 					GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.door, 3), "xx", "xx", "xx", 'x', Oredicts.INGOT + oreDictName));
 					GameRegistry.addSmelting(material.door, new ItemStack(material.ingot, 2), 0);
 //					OreDictionary.registerOre(Oredicts.DOOR, material.door);
@@ -336,14 +251,14 @@ public abstract class Recipes {
 					GameRegistry.addSmelting(material.shield, new ItemStack(material.ingot, 6), 0); // 1 wood loss
 				}
 
-				if (material.trapdoor != null) {
+				if ((material.trapdoor != null) && (material.trapdoor instanceof IMetalObject)) {
 					GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.trapdoor), "xx", "xx", 'x', Oredicts.INGOT + oreDictName));
 					GameRegistry.addSmelting(material.trapdoor, new ItemStack(material.ingot, 4), 0);
 //					OreDictionary.registerOre(Oredicts.TRAPDOOR, material.trapdoor);
 				}
 
 				// Diamond, Gold & Iron Horse armor are in vanilla so dont do them for vanilla mats
-				if (!(material.isVanilla) && (material.horse_armor != null)) {
+				if ((material.horse_armor instanceof IMetalObject) && (material.horse_armor != null)) {
 					GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.horse_armor), "  x", "xyx", "xxx", 'x', Oredicts.INGOT + oreDictName, 'y', net.minecraft.init.Blocks.WOOL));
 					GameRegistry.addSmelting(material.horse_armor, new ItemStack(material.ingot, 6), 0); // 1 wool loss
 				}
@@ -423,6 +338,96 @@ public abstract class Recipes {
 					CrusherRecipeRegistry.addNewCrusherRecipe(Oredicts.NUGGET + oreDictName, new ItemStack(material.smallpowder, 1));
 				}
 			}
+		}
+	}
+
+	private static void generateBaseTools(final MetalMaterial material, final String oreDictName) {
+		if (material.boots != null) {
+			GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.boots), "x x", "x x", 'x', Oredicts.INGOT + oreDictName));
+			if (Config.Options.furnaceCheese) {
+				GameRegistry.addSmelting(material.boots, new ItemStack(material.ingot, 4), 0);
+			} else if (Config.Options.furnace1112) {						
+				GameRegistry.addSmelting(material.boots, new ItemStack(material.nugget, 1), 0);
+			}
+		}
+
+		if (material.helmet != null) {
+			GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.helmet), "xxx", "x x", 'x', Oredicts.INGOT + oreDictName));
+			if (Config.Options.furnaceCheese) {
+				GameRegistry.addSmelting(material.helmet, new ItemStack(material.ingot, 5), 0);
+			} else if (Config.Options.furnace1112) {						
+				GameRegistry.addSmelting(material.helmet, new ItemStack(material.nugget, 1), 0);
+			}
+		}
+
+		if (material.chestplate != null) {
+			GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.chestplate), "x x", "xxx", "xxx", 'x', Oredicts.INGOT + oreDictName));
+			if (Config.Options.furnaceCheese) {
+				GameRegistry.addSmelting(material.chestplate, new ItemStack(material.ingot, 8), 0);
+			} else if (Config.Options.furnace1112) {						
+				GameRegistry.addSmelting(material.chestplate, new ItemStack(material.nugget, 1), 0);
+			}
+		}
+
+		if (material.leggings != null) {
+			GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.leggings), "xxx", "x x", "x x", 'x', Oredicts.INGOT + oreDictName));
+			if (Config.Options.furnaceCheese) {
+				GameRegistry.addSmelting(material.chestplate, new ItemStack(material.leggings, 7), 0);
+			} else if (Config.Options.furnace1112) {						
+				GameRegistry.addSmelting(material.leggings, new ItemStack(material.nugget, 1), 0);
+			}
+		}
+
+		if (material.axe != null) {
+			GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.axe), "xx", "x/", " /", 'x', Oredicts.INGOT + oreDictName, '/', Oredicts.STICKWOOD));
+			// 	GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.axe), "xx", "/x", "/ ", 'x', Oredicts.INGOT + oreDictName, '/', Oredicts.STICKWOOD));
+			if (Config.Options.furnaceCheese) {
+				GameRegistry.addSmelting(material.axe, new ItemStack(material.ingot, 3), 0);
+			} else if (Config.Options.furnace1112) {						
+				GameRegistry.addSmelting(material.axe, new ItemStack(material.nugget, 1), 0);
+			}
+		}
+
+		if (material.hoe != null) {
+			GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.hoe), "xx", " /", " /", 'x', Oredicts.INGOT + oreDictName, '/', Oredicts.STICKWOOD));
+			// 	GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.hoe), "xx", "/ ", "/ ", 'x', INGOT + oreDictName, '/', STICKWOOD));
+			if (Config.Options.furnaceCheese) {
+				GameRegistry.addSmelting(material.hoe, new ItemStack(material.ingot, 2), 0);
+			} else if (Config.Options.furnace1112) {						
+				GameRegistry.addSmelting(material.hoe, new ItemStack(material.nugget, 1), 0);
+			}
+		}
+
+		if (material.pickaxe != null) {
+			GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.pickaxe), "xxx", " / ", " / ", 'x', Oredicts.INGOT + oreDictName, '/', Oredicts.STICKWOOD));
+			if (Config.Options.furnaceCheese) {
+				GameRegistry.addSmelting(material.pickaxe, new ItemStack(material.ingot, 3), 0);
+			} else if (Config.Options.furnace1112) {						
+				GameRegistry.addSmelting(material.pickaxe, new ItemStack(material.nugget, 1), 0);
+			}
+		}
+
+		if (material.shovel != null) {
+			GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.shovel), "x", "/", "/", 'x', Oredicts.INGOT + oreDictName, '/', Oredicts.STICKWOOD));
+			if (Config.Options.furnaceCheese) {
+				GameRegistry.addSmelting(material.shovel, new ItemStack(material.ingot, 1), 0);
+			} else if (Config.Options.furnace1112) {						
+				GameRegistry.addSmelting(material.shovel, new ItemStack(material.nugget, 1), 0);
+			}
+		}
+
+		if (material.sword != null) {
+			GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.sword), "x", "x", "/", 'x', Oredicts.INGOT + oreDictName, '/', Oredicts.STICKWOOD));
+			if (Config.Options.furnaceCheese) {
+				GameRegistry.addSmelting(material.sword, new ItemStack(material.ingot, 2), 0);
+			} else if (Config.Options.furnace1112) {						
+				GameRegistry.addSmelting(material.sword, new ItemStack(material.nugget, 1), 0);
+			}
+		}
+
+		if (material.shears != null) {
+			GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(material.shears), " x", "x ", 'x', Oredicts.INGOT + oreDictName));
+			GameRegistry.addSmelting(material.shears, new ItemStack(material.ingot, 2), 0);
 		}
 	}
 


### PR DESCRIPTION
Fix initGeneralRecipes so it can be used for any material - even vanilla ones. As part of this add guards to places where vanilla already has a recipe for the item in question and refactor the code creating armor and tools to a separate function.

Since initGeneralRecipes is now handling all the work of creating the powders/items/etc... runVanillaMaterialRecipes is no longer needed and has been removed.