### PR TITLE
Update the TCon plugin to use TCon's API instead of IMC

### DIFF
--- a/src/main/java/com/mcmoddev/basemetals/integration/plugins/TinkersConstruct.java
+++ b/src/main/java/com/mcmoddev/basemetals/integration/plugins/TinkersConstruct.java
@@ -4,6 +4,10 @@ import com.mcmoddev.basemetals.init.Materials;
 import com.mcmoddev.basemetals.integration.BaseMetalsPlugin;
 import com.mcmoddev.basemetals.util.Config.Options;
 import com.mcmoddev.lib.integration.IIntegration;
+import com.mcmoddev.lib.material.MetalMaterial;
+
+import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
 
 /**
  *
@@ -105,12 +109,11 @@ public class TinkersConstruct extends com.mcmoddev.lib.integration.plugins.Tinke
 			registerMaterial(Materials.platinum.getName(), false, true);
 		}
 
-		/*
-		if (Options.ENABLE_SILVER) {
-			registerMaterial(Materials.silver.getName(), false, true);
+		if( Options.enableSteel) {
+			registerAlloy(Materials.steel.fluid.getName(), 8, 
+					new String[] { "iron","coal" }, 
+					new int[]{8,1});
 		}
-		*/
-
 
 		if (Options.enableStarSteel) {
 			registerMaterial(Materials.starsteel.getName(), false, true);

--- a/src/main/java/com/mcmoddev/lib/integration/plugins/TinkersConstruct.java
+++ b/src/main/java/com/mcmoddev/lib/integration/plugins/TinkersConstruct.java
@@ -3,7 +3,10 @@ package com.mcmoddev.lib.integration.plugins;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fml.common.event.FMLInterModComms;
+
 import org.apache.commons.lang3.StringUtils;
 
 import com.mcmoddev.lib.integration.IIntegration;
@@ -71,25 +74,13 @@ public class TinkersConstruct implements IIntegration {
 			throw new RuntimeException("Alloy must have the same amount of inputName and intQty");
 		}
 
-		final NBTTagList tagList = new NBTTagList();
-
-		// if you have access to the fluid-instance you can also do FluidStack.writeToNBT
-		NBTTagCompound fluid = new NBTTagCompound();
-		fluid.setString("FluidName", outputName);
-		fluid.setInteger("Amount", outputQty); // 144 = 1 ingot, 16 = 1 nugget
-		tagList.appendTag(fluid);
-
-		// alloy fluid
-		for (int i = 0; i < inputName.length; i++) {
-			fluid = new NBTTagCompound();
-			fluid.setString("FluidName", inputName[i]);
-			fluid.setInteger("Amount", inputQty[i]);
-			tagList.appendTag(fluid);
+		FluidStack output = FluidRegistry.getFluidStack(outputName, outputQty);
+		FluidStack[] input = new FluidStack[inputName.length];
+		for( int i = 0; i < inputName.length; i++ ) {
+			input[i] = FluidRegistry.getFluidStack(inputName[i], inputQty[i]);
 		}
-
-		final NBTTagCompound message = new NBTTagCompound();
-		message.setTag("alloy", tagList);
-		FMLInterModComms.sendMessage(PLUGIN_MODID, "alloy", message);
+		
+		TinkerRegistry.registerAlloy(output, input);
 	}
 
 	protected static void registerMaterial(String name, boolean craftable, boolean castable) {


### PR DESCRIPTION
This updates the TCon plugins 'registerAlloy' method to utilize the TCon TinkerRegistry API to register Steel as an alloy and re-enables the call to do such in BMe.
