### PR TITLE
Lint cleanups and a minor TiC plugin API change to restrict references to TiC internals to MMDLib

### DIFF
--- a/src/main/java/com/mcmoddev/basemetals/integration/plugins/TinkersConstruct.java
+++ b/src/main/java/com/mcmoddev/basemetals/integration/plugins/TinkersConstruct.java
@@ -1,14 +1,12 @@
 package com.mcmoddev.basemetals.integration.plugins;
 
-//import com.mcmoddev.basemetals.BaseMetals;
 import com.mcmoddev.basemetals.init.Materials;
 import com.mcmoddev.basemetals.integration.BaseMetalsPlugin;
 import com.mcmoddev.basemetals.util.Config.Options;
 import com.mcmoddev.lib.integration.IIntegration;
 import com.mcmoddev.lib.integration.plugins.tinkers.TCMetalMaterial;
-import com.mcmoddev.lib.integration.plugins.tinkers.traits.*;
+import com.mcmoddev.lib.integration.plugins.tinkers.TraitRegistry;
 
-import slimeknights.tconstruct.tools.TinkerTraits;
 import slimeknights.tconstruct.library.materials.MaterialTypes;
 
 /**
@@ -26,6 +24,10 @@ public class TinkersConstruct extends com.mcmoddev.lib.integration.plugins.Tinke
 		if (initDone || !com.mcmoddev.basemetals.util.Config.Options.enableTinkersConstruct) {
 			return;
 		}
+		
+		TraitRegistry.initTiCTraits();
+		TraitRegistry.initMetalsTraits();
+		TraitRegistry.dumpRegistry();
 
 		if (Options.enableAdamantine) {
 			/*
@@ -35,8 +37,8 @@ public class TinkersConstruct extends com.mcmoddev.lib.integration.plugins.Tinke
 			 */
 			TCMetalMaterial adamantTC = new TCMetalMaterial(Materials.adamantine);
 			adamantTC.craftable = false;
-			adamantTC.addTrait(TinkerTraits.coldblooded);
-			adamantTC.addTrait(TinkerTraits.insatiable, MaterialTypes.HEAD);
+			adamantTC.addTrait("coldblooded");
+			adamantTC.addTrait("insatiable", MaterialTypes.HEAD);
 
 			registerMaterial(adamantTC);
 		}
@@ -51,9 +53,9 @@ public class TinkersConstruct extends com.mcmoddev.lib.integration.plugins.Tinke
 		if (Options.enableAquarium) {
 			TCMetalMaterial aquaTC = new TCMetalMaterial(Materials.aquarium);
 			aquaTC.craftable = false;
-			aquaTC.addTrait(TinkerTraits.aquadynamic);
-			aquaTC.addTrait(TinkerTraits.jagged, MaterialTypes.HEAD);
-			aquaTC.addTrait(TinkerTraits.aquadynamic, MaterialTypes.HEAD);
+			aquaTC.addTrait("aquadynamic");
+			aquaTC.addTrait("jagged", MaterialTypes.HEAD);
+			aquaTC.addTrait("aquadynamic", MaterialTypes.HEAD);
 
 			registerMaterial(aquaTC);
 			// When FMe is out we can probably do the alloy.
@@ -72,7 +74,7 @@ public class TinkersConstruct extends com.mcmoddev.lib.integration.plugins.Tinke
 		if (Options.enableBrass) {
 			TCMetalMaterial brassTC = new TCMetalMaterial(Materials.brass);
 			brassTC.craftable = false;
-			brassTC.addTrait(TinkerTraits.dense);
+			brassTC.addTrait("dense");
 
 			registerMaterial(brassTC);
 		}
@@ -84,7 +86,7 @@ public class TinkersConstruct extends com.mcmoddev.lib.integration.plugins.Tinke
 		if (Options.enableColdIron) {
 			TCMetalMaterial coldironTC = new TCMetalMaterial(Materials.coldiron);
 			coldironTC.craftable = false;
-			coldironTC.addTrait(TinkerTraits.freezing);
+			coldironTC.addTrait("freezing");
 
 			registerMaterial(coldironTC);
 		}
@@ -114,10 +116,12 @@ public class TinkersConstruct extends com.mcmoddev.lib.integration.plugins.Tinke
 		// up to the point of registration, the state changes and
 		// lead is suddenly registered.
 		// There will have to be another means of making this work...
+		// There is an event TiC has that covers material registration
+		// we could hook that...
 /*		if (Options.enableLead) {
 			TCMetalMaterial leadTC = new TCMetalMaterial(Materials.lead);
 			leadTC.craftable = false;
-			leadTC.addTrait(MMDTraits.soft);
+			leadTC.addTrait("soft");
 			
 			registerMaterial(leadTC);
 		} 
@@ -129,15 +133,13 @@ public class TinkersConstruct extends com.mcmoddev.lib.integration.plugins.Tinke
 		if (Options.enableMithril) {
 			TCMetalMaterial mithrilTC = new TCMetalMaterial(Materials.mithril);
 			mithrilTC.craftable = false;
-			mithrilTC.addTrait(TinkerTraits.holy);
+			mithrilTC.addTrait("holy");
 
 			registerMaterial(mithrilTC);
 			
-			if( Options.enableMercury && Options.enableSilver && Options.enableColdIron ) {
 				registerAlloy(Materials.mithril.getName(), 3,
 						new String[] { "silver", "coldiron", "mercury" },
 						new int[] { 2, 1, 1});
-			}
 		}
 
 		if (Options.enableNickel) {
@@ -151,7 +153,7 @@ public class TinkersConstruct extends com.mcmoddev.lib.integration.plugins.Tinke
 		if (Options.enablePewter) {
 			TCMetalMaterial pewterTC = new TCMetalMaterial(Materials.pewter);
 			pewterTC.craftable = false;
-			pewterTC.addTrait(MMDTraits.soft);
+			pewterTC.addTrait("soft");
 
 			registerMaterial(pewterTC);
 			// this makes what the "Worshipful Company of Pewterers" called "trifle"
@@ -182,8 +184,8 @@ public class TinkersConstruct extends com.mcmoddev.lib.integration.plugins.Tinke
 		if (Options.enableStarSteel) {
 			TCMetalMaterial starsteelTC = new TCMetalMaterial(Materials.starsteel);
 			starsteelTC.craftable = false;
-			starsteelTC.addTrait(TinkerTraits.enderference, MaterialTypes.HEAD);
-			starsteelTC.addTrait(MMDTraits.sparkly);
+			starsteelTC.addTrait("enderference", MaterialTypes.HEAD);
+			starsteelTC.addTrait("sparkly");
 
 			registerMaterial(starsteelTC);
 		}

--- a/src/main/java/com/mcmoddev/lib/integration/plugins/TinkersConstruct.java
+++ b/src/main/java/com/mcmoddev/lib/integration/plugins/TinkersConstruct.java
@@ -7,10 +7,14 @@ import net.minecraftforge.fluids.FluidStack;
 
 import com.mcmoddev.lib.integration.IIntegration;
 import com.mcmoddev.lib.material.MetalMaterial;
-//import com.mcmoddev.basemetals.BaseMetals;
+
+import java.util.Random;
+
+import com.mcmoddev.basemetals.BaseMetals;
 import com.mcmoddev.lib.init.Materials;
 import com.mcmoddev.lib.util.Oredicts;
 import com.mcmoddev.lib.integration.plugins.tinkers.TCMetalMaterial;
+import com.mcmoddev.lib.integration.plugins.tinkers.TraitRegistry;
 
 import slimeknights.tconstruct.library.TinkerRegistry;
 import slimeknights.tconstruct.library.materials.ArrowShaftMaterialStats;
@@ -41,6 +45,7 @@ public class TinkersConstruct implements IIntegration {
 		if (initDone || !com.mcmoddev.basemetals.util.Config.Options.enableTinkersConstruct) {
 			return;
 		}
+
 
 		initDone = true;
 	}
@@ -87,7 +92,14 @@ public class TinkersConstruct implements IIntegration {
 		FluidStack output = FluidRegistry.getFluidStack(outputName, outputQty);
 		FluidStack[] input = new FluidStack[inputName.length];
 		for( int i = 0; i < inputName.length; i++ ) {
-			input[i] = FluidRegistry.getFluidStack(inputName[i], inputQty[i]);
+			FluidStack temp = FluidRegistry.getFluidStack(inputName[i], inputQty[i]);
+			if ( temp != null ) {
+				input[i] = FluidRegistry.getFluidStack(inputName[i], inputQty[i]);
+			} else {
+				String mess = String.format("BaseMetals-TCon: material %s is not a registered fluid, alloy recipe %s ignored.", inputName[i], outputName);
+				BaseMetals.logger.error(mess);
+				return;
+			}
 		}
 
 		TinkerRegistry.registerAlloy(output, input);
@@ -108,8 +120,11 @@ public class TinkersConstruct implements IIntegration {
 		TCMetalMaterial m = new TCMetalMaterial(material);
 		m.craftable = craftable;
 		m.castable = castable;
-		if (trait != null)
-			m.addTrait(trait);
+		if (trait != null) {
+			String randName = ((Integer)(new Random()).nextInt()).toString();
+			TraitRegistry.addTrait(randName, trait);
+			m.addTrait(randName);
+		}
 		
 		registerMaterial(m);
 	}

--- a/src/main/java/com/mcmoddev/lib/integration/plugins/tinkers/TCMetalMaterial.java
+++ b/src/main/java/com/mcmoddev/lib/integration/plugins/tinkers/TCMetalMaterial.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.Set;
 
 import com.mcmoddev.lib.material.MetalMaterial;
+import com.mcmoddev.basemetals.BaseMetals;
+import com.mcmoddev.lib.integration.plugins.tinkers.TraitRegistry;
 
 import slimeknights.tconstruct.library.traits.AbstractTrait;
 import slimeknights.tconstruct.library.traits.ITrait;
@@ -45,7 +47,7 @@ public class TCMetalMaterial {
 	public float fletchingModifier;
 
 	// for reference and simplifying the API
-	final public MetalMaterial metalmaterial;
+	public final MetalMaterial metalmaterial;
 
 	// craftable, castable, toolforge - does this allow it ?
 	public boolean craftable;
@@ -54,8 +56,7 @@ public class TCMetalMaterial {
 
 	public boolean hasTraits;
 
-	private HashMap<String, List<AbstractTrait>> traits = new HashMap<String, List<AbstractTrait>>();
-	//private AbstractTrait[] traits = new AbstractTrait[9];
+	private HashMap<String,List<AbstractTrait>> traits = new HashMap<>();
 
 	/**
 	 * @param material MetalMaterial this represents
@@ -103,9 +104,8 @@ public class TCMetalMaterial {
 	 * Add a TiC default or custom trait to the material in general
 	 * @param trait the AbstractTrait to add
 	 */
-	public void addTrait(ITrait trait) {
-		hasTraits = true;
-		addTrait(trait, "general");
+	public void addTrait(String traitName) {
+		addTrait(traitName, "general");
 	}
 
 	/**
@@ -114,13 +114,19 @@ public class TCMetalMaterial {
 	 * @param loc the MaterialType for the tool part {@link slimeknights.tconstruct.library.material.MaterialType}
 	 * @throws
 	 */
-	public void addTrait(ITrait trait, String loc) {
+	public void addTrait(String traitName, String loc) {
+		ITrait trait = TraitRegistry.get(traitName);
+		if( trait == null ) {
+			String s = String.format("BaseMetals-TCon: Asked for trait %s that does not exist", traitName);
+			BaseMetals.logger.error(s);
+			return;
+		}
 		if (traits.keySet().contains(loc)) {
 			if (!traits.get(loc).add((AbstractTrait)trait)) { 
-				throw new Error("Unable to add trait!");
+				throw new RuntimeException("Unable to add trait!");
 			}
 		} else {
-			List<AbstractTrait> t = new ArrayList<AbstractTrait>();
+			List<AbstractTrait> t = new ArrayList<>();
 			t.add((AbstractTrait)trait);
 			traits.put(loc, t);
 		}
@@ -136,7 +142,7 @@ public class TCMetalMaterial {
 	 */
 	public List<AbstractTrait> getTraits(String loc) {
 		if (!hasTraits) {
-			return null;
+			return new ArrayList<>();
 		}
 
 		if( loc == null ) {
@@ -144,15 +150,15 @@ public class TCMetalMaterial {
 		} else if (traits.keySet().contains(loc)) {
 			return traits.get(loc);
 		} else {
-			throw new Error("Unkown trait location " + loc);
+			throw new RuntimeException("Unkown trait location " + loc);
 		}
 	}
-
+	
 	/**
 	 * Get the names of the keys in the traits HashMap
 	 * @return Set<String>
 	 */
 	public Set<String> getTraitLocs() {
 		return traits.keySet();
-	}	
+	}
 }

--- a/src/main/java/com/mcmoddev/lib/integration/plugins/tinkers/TraitRegistry.java
+++ b/src/main/java/com/mcmoddev/lib/integration/plugins/tinkers/TraitRegistry.java
@@ -1,0 +1,65 @@
+package com.mcmoddev.lib.integration.plugins.tinkers;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.mcmoddev.basemetals.BaseMetals;
+
+import slimeknights.tconstruct.library.traits.ITrait;
+
+public class TraitRegistry {
+
+	private static Map<String, ITrait> registeredTraits = new HashMap<>();
+	
+	public static void addTrait(String name, ITrait trait) {
+		registeredTraits.put(name, trait);
+	}
+	
+	public static boolean hasTrait(String name) {
+		return registeredTraits.keySet().contains(name);
+	}
+	
+	public static ITrait getTrait(String name) {
+		return registeredTraits.get(name);
+	}
+	
+	public static ITrait get(String name) {
+		return getTrait(name);
+	}
+	
+	public static void initTiCTraits() {
+		Field[] fields = slimeknights.tconstruct.tools.TinkerTraits.class.getDeclaredFields();
+		for( Field f : fields ) {
+			Class<?> clazz= f.getType();
+			try {
+				registeredTraits.put(f.getName(), (ITrait)f.get(clazz));
+			} catch (final Exception e) {
+				// do nothing
+			}
+		}
+	}
+	
+	public static void initMetalsTraits() {
+		Field[] fields = com.mcmoddev.lib.integration.plugins.tinkers.traits.MMDTraits.class.getDeclaredFields();
+		for( Field f : fields ) {
+			Class<?> clazz = f.getType();
+			try {
+				registeredTraits.put(f.getName(), (ITrait)f.get(clazz));
+			} catch( final Exception e ) {
+				// do nothing
+			}
+		}
+	}
+	
+	public static void dumpRegistry() {
+		for( String s : registeredTraits.keySet()) {
+			String t = String.format("BaseMetals-TCon> Trait: %s - class %s", s, registeredTraits.get(s).getClass().getName());
+			BaseMetals.logger.info(t);
+		}
+	}
+	
+	public TraitRegistry() {
+		throw new IllegalAccessError("Not an instantiable class");
+	}
+}


### PR DESCRIPTION
Some lint cleanups and a change to the API that moves direct references to Tinkers Construct code almost entirely into the MMDLib side of things. The last remaining direct reference is to the 'MaterialTypes' set of constants - something I am unsure of how to actually resolve.

The TraitRegisty is to be used for all access to registered traits - every custom trait in *Metals is in it as well
as it autiomatically importing all default Tinkers' Construct traits.