### PR TITLE
Make *metals metal blocks work as beacon bases. Fixes #65

### DIFF
--- a/src/main/java/com/mcmoddev/lib/blocks/BlockMetalBlock.java
+++ b/src/main/java/com/mcmoddev/lib/blocks/BlockMetalBlock.java
@@ -13,6 +13,7 @@ import net.minecraft.block.material.MapColor;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -27,7 +28,8 @@ public class BlockMetalBlock extends Block implements IOreDictionaryEntry, IMeta
 
 	private final MetalMaterial material;
 	private final String oreDict;
-
+	private final boolean beaconBase;
+	
 	/**
 	 *
 	 * @param material The material the block is made from
@@ -37,6 +39,10 @@ public class BlockMetalBlock extends Block implements IOreDictionaryEntry, IMeta
 	}
 
 	public BlockMetalBlock(MetalMaterial material, boolean glows) {
+		this(material,glows,false);
+	}
+	
+	public BlockMetalBlock(MetalMaterial material, boolean glows, boolean isBeacon) {
 		super(Material.IRON);
 		this.setSoundType(SoundType.METAL);
 		this.fullBlock = true;
@@ -48,10 +54,17 @@ public class BlockMetalBlock extends Block implements IOreDictionaryEntry, IMeta
 		this.blockHardness = material.getMetalBlockHardness();
 		this.blockResistance = material.getBlastResistance();
 		this.setHarvestLevel("pickaxe", material.getRequiredHarvestLevel());
+		this.beaconBase = isBeacon;
+		
 		if (glows)
 			this.setLightLevel(0.5f);
 	}
-
+	
+    @Override
+    public boolean isBeaconBase(IBlockAccess worldObj, BlockPos pos, BlockPos beacon) {
+        return beaconBase;
+    }
+    
 	///// OVERRIDE OF ALL METHODS THAT DEPEND ON BLOCK MATERIAL: /////
 	/**
 	 * @deprecated

--- a/src/main/java/com/mcmoddev/lib/init/Blocks.java
+++ b/src/main/java/com/mcmoddev/lib/init/Blocks.java
@@ -210,7 +210,7 @@ public abstract class Blocks {
 		}
 
 		if ((Options.enableBasics) && (material.block == null)) {
-			material.block = addBlock(new BlockMetalBlock(material, glow), "block", material, ItemGroups.blocksTab);
+			material.block = addBlock(new BlockMetalBlock(material, glow, true), "block", material, ItemGroups.blocksTab);
 		}
 		return material.block;
 	}


### PR DESCRIPTION
It would take an AT and a lot more work to add custom effects, but this allows *metals materials to be used as bases for beacons.